### PR TITLE
feat: add shared UI kit with buttons, inputs, cards, and reusable components

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'theme/app_theme.dart';
 import 'utils/routes.dart';
+import 'package:dayflow/widgets/ui_kit.dart';
 
 void main() {
   runApp(const DayFlowApp());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'pages/welcome_page.dart';
+import 'package:provider/provider.dart';
+import 'theme/app_theme.dart';
+import 'utils/routes.dart';
 
 void main() {
   runApp(const DayFlowApp());
@@ -10,11 +12,21 @@ class DayFlowApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'DayFlow',
-      theme: ThemeData.light(),
-      home: const WelcomePage(),
+    return ChangeNotifierProvider(
+      create: (_) => ThemeProvider(),
+      child: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, _) {
+          return MaterialApp(
+            title: 'DayFlow',
+            debugShowCheckedModeBanner: false,
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
+            themeMode: themeProvider.themeMode,
+            initialRoute: Routes.welcome,
+            routes: Routes.routes,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/pages/habits_page.dart
+++ b/lib/pages/habits_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-class SettingsPage extends StatelessWidget {
-  const SettingsPage({super.key});
+class HabitsPage extends StatelessWidget {
+  const HabitsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -10,18 +10,18 @@ class SettingsPage extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(
-            Icons.settings_outlined,
+            Icons.track_changes_outlined,
             size: 80,
             color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
           ),
           const SizedBox(height: 24),
           Text(
-            'Settings Page',
+            'Habits Page',
             style: Theme.of(context).textTheme.headlineMedium,
           ),
           const SizedBox(height: 8),
           Text(
-            'Customization options coming soon!',
+            'Habits-Trancking management coming soon!',
             style: Theme.of(context).textTheme.bodyMedium,
           ),
         ],

--- a/lib/pages/notes_page.dart
+++ b/lib/pages/notes_page.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class NotesPage extends StatelessWidget {
+  const NotesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.note_outlined,
+            size: 80,
+            color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Notes Page',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Note-taking features coming soon!',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/reminders_page.dart
+++ b/lib/pages/reminders_page.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class RemindersPage extends StatelessWidget {
+  const RemindersPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.alarm_outlined,
+            size: 80,
+            color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Reminders Page',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Reminder notifications coming soon!',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/todo_page.dart
+++ b/lib/pages/todo_page.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class TodoPage extends StatelessWidget {
+  const TodoPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.check_circle_outline,
+            size: 80,
+            color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Todo Page',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Task management coming soon!',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -1,50 +1,200 @@
 import 'package:flutter/material.dart';
+import 'dart:math' as math;
 import '../utils/routes.dart';
 
-class WelcomePage extends StatelessWidget {
+class WelcomePage extends StatefulWidget {
   const WelcomePage({super.key});
+
+  @override
+  State<WelcomePage> createState() => _WelcomePageState();
+}
+
+class _WelcomePageState extends State<WelcomePage> with TickerProviderStateMixin {
+  late AnimationController _gradientController;
+  late AnimationController _contentController;
+  late AnimationController _buttonController;
+
+  late Animation<double> _logoOpacity;
+  late Animation<double> _logoScale;
+  late Animation<Offset> _titleSlide;
+  late Animation<double> _titleOpacity;
+  late Animation<double> _taglineOpacity;
+  late Animation<double> _featuresOpacity;
+  late Animation<Offset> _buttonSlide;
+  late Animation<double> _buttonOpacity;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Gradient animation controller (continuous)
+    _gradientController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 8),
+    )..repeat();
+
+    // Content animation controller
+    _contentController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    );
+
+    // Button animation controller (delayed)
+    _buttonController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+
+    // Logo animations (0-400ms)
+    _logoOpacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _contentController,
+        curve: const Interval(0.0, 0.2, curve: Curves.easeOut),
+      ),
+    );
+
+    _logoScale = Tween<double>(begin: 0.5, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _contentController,
+        curve: const Interval(0.0, 0.3, curve: Curves.elasticOut),
+      ),
+    );
+
+    // Title animations (200-600ms)
+    _titleSlide = Tween<Offset>(
+      begin: const Offset(0, 0.5),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _contentController,
+        curve: const Interval(0.1, 0.3, curve: Curves.easeOut),
+      ),
+    );
+
+    _titleOpacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _contentController,
+        curve: const Interval(0.1, 0.3, curve: Curves.easeIn),
+      ),
+    );
+
+    // Tagline animation (400-800ms)
+    _taglineOpacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _contentController,
+        curve: const Interval(0.2, 0.4, curve: Curves.easeIn),
+      ),
+    );
+
+    // Features animation (600-1200ms)
+    _featuresOpacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _contentController,
+        curve: const Interval(0.3, 0.6, curve: Curves.easeIn),
+      ),
+    );
+
+    // Button animations
+    _buttonSlide = Tween<Offset>(
+      begin: const Offset(0, 0.5),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _buttonController,
+        curve: Curves.easeOut,
+      ),
+    );
+
+    _buttonOpacity = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _buttonController,
+        curve: Curves.easeIn,
+      ),
+    );
+
+    // Start animations
+    _contentController.forward();
+    Future.delayed(const Duration(milliseconds: 1200), () {
+      if (mounted) _buttonController.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _gradientController.dispose();
+    _contentController.dispose();
+    _buttonController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              Theme.of(context).colorScheme.primary,
-              Theme.of(context).colorScheme.secondary,
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+      body: AnimatedBuilder(
+        animation: _gradientController,
+        builder: (context, child) {
+          return Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  Theme.of(context).colorScheme.primary,
+                  Theme.of(context).colorScheme.secondary,
+                  Theme.of(context).colorScheme.primary,
+                ],
+                begin: Alignment(
+                  math.cos(_gradientController.value * 2 * math.pi) * 0.5,
+                  math.sin(_gradientController.value * 2 * math.pi) * 0.5,
+                ),
+                end: Alignment(
+                  -math.cos(_gradientController.value * 2 * math.pi) * 0.5,
+                  -math.sin(_gradientController.value * 2 * math.pi) * 0.5,
+                ),
+              ),
+            ),
+            child: Stack(
               children: [
-                const Spacer(),
+                // Animated background shapes
+                ..._buildBackgroundShapes(),
 
-                // App Logo
-                Container(
-                  width: 120,
-                  height: 120,
-                  decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.2),
-                    borderRadius: BorderRadius.circular(30),
-                  ),
-                  child: const Icon(
-                    Icons.water_drop_rounded,
-                    size: 64,
-                    color: Colors.white,
+                // Main content
+                SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24.0),
+                    child: child!,
                   ),
                 ),
+              ],
+            ),
+          );
+        },
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Spacer(),
 
-                const SizedBox(height: 32),
+            // Animated Logo
+            AnimatedBuilder(
+              animation: _contentController,
+              builder: (context, child) {
+                return Opacity(
+                  opacity: _logoOpacity.value,
+                  child: Transform.scale(
+                    scale: _logoScale.value,
+                    child: child,
+                  ),
+                );
+              },
+              child: _AnimatedLogo(),
+            ),
 
-                // App Name
-                const Text(
+            const SizedBox(height: 32),
+
+            // Animated App Name
+            SlideTransition(
+              position: _titleSlide,
+              child: FadeTransition(
+                opacity: _titleOpacity,
+                child: const Text(
                   'DayFlow',
                   style: TextStyle(
                     fontSize: 48,
@@ -53,131 +203,348 @@ class WelcomePage extends StatelessWidget {
                     letterSpacing: 1.2,
                   ),
                 ),
+              ),
+            ),
 
-                const SizedBox(height: 12),
+            const SizedBox(height: 12),
 
-                // Tagline
-                Text(
-                  'Your Smart Daily Planner',
-                  style: TextStyle(
-                    fontSize: 18,
-                    color: Colors.white.withOpacity(0.9),
-                    fontWeight: FontWeight.w300,
+            // Animated Tagline
+            FadeTransition(
+              opacity: _taglineOpacity,
+              child: Text(
+                'Your Smart Daily Planner',
+                style: TextStyle(
+                  fontSize: 18,
+                  color: Colors.white.withOpacity(0.9),
+                  fontWeight: FontWeight.w300,
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 48),
+
+            // Animated Features List
+            FadeTransition(
+              opacity: _featuresOpacity,
+              child: Column(
+                children: [
+                  _AnimatedFeatureItem(
+                    icon: Icons.check_circle_outline,
+                    text: 'Organize your tasks efficiently',
+                    delay: 0,
                   ),
-                ),
+                  const SizedBox(height: 16),
+                  _AnimatedFeatureItem(
+                    icon: Icons.note_outlined,
+                    text: 'Capture ideas instantly',
+                    delay: 100,
+                  ),
+                  const SizedBox(height: 16),
+                  _AnimatedFeatureItem(
+                    icon: Icons.alarm_outlined,
+                    text: 'Never miss important reminders',
+                    delay: 200,
+                  ),
+                ],
+              ),
+            ),
 
-                const SizedBox(height: 48),
+            const Spacer(),
 
-                // Feature List
-                _FeatureItem(
-                  icon: Icons.check_circle_outline,
-                  text: 'Organize your tasks efficiently',
-                ),
-                const SizedBox(height: 16),
-                _FeatureItem(
-                  icon: Icons.note_outlined,
-                  text: 'Capture ideas instantly',
-                ),
-                const SizedBox(height: 16),
-                _FeatureItem(
-                  icon: Icons.alarm_outlined,
-                  text: 'Never miss important reminders',
-                ),
-
-                const Spacer(),
-
-                // Get Started Button
-                SizedBox(
+            // Animated Get Started Button
+            SlideTransition(
+              position: _buttonSlide,
+              child: FadeTransition(
+                opacity: _buttonOpacity,
+                child: SizedBox(
                   width: double.infinity,
                   height: 56,
-                  child: ElevatedButton(
+                  child: _PulsingButton(
                     onPressed: () {
                       Routes.navigateToHome(context);
                     },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: Theme.of(context).colorScheme.primary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      elevation: 0,
-                    ),
-                    child: const Text(
-                      'Get Started',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
                   ),
                 ),
+              ),
+            ),
 
-                const SizedBox(height: 16),
+            const SizedBox(height: 16),
 
-                // Sign In Link
-                TextButton(
-                  onPressed: () {
-                    // TODO: Navigate to sign in
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Sign in coming soon!')),
-                    );
-                  },
-                  child: const Text(
-                    'Already have an account? Sign In',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 14,
-                    ),
+            // Animated Sign In Link
+            FadeTransition(
+              opacity: _buttonOpacity,
+              child: TextButton(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Sign in coming soon!')),
+                  );
+                },
+                child: const Text(
+                  'Already have an account? Sign In',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 14,
                   ),
                 ),
+              ),
+            ),
 
-                const SizedBox(height: 24),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildBackgroundShapes() {
+    return List.generate(5, (index) {
+      return AnimatedBuilder(
+        animation: _gradientController,
+        builder: (context, child) {
+          final progress = (_gradientController.value + index * 0.2) % 1.0;
+          return Positioned(
+            left: MediaQuery.of(context).size.width * progress - 50,
+            top: 50.0 + index * 150.0,
+            child: Opacity(
+              opacity: 0.1,
+              child: Transform.rotate(
+                angle: progress * 2 * math.pi,
+                child: Container(
+                  width: 100,
+                  height: 100,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+    });
+  }
+}
+
+// Animated Logo Widget
+class _AnimatedLogo extends StatefulWidget {
+  @override
+  State<_AnimatedLogo> createState() => _AnimatedLogoState();
+}
+
+class _AnimatedLogoState extends State<_AnimatedLogo> with SingleTickerProviderStateMixin {
+  late AnimationController _pulseController;
+  late Animation<double> _pulseAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    )..repeat(reverse: true);
+
+    _pulseAnimation = Tween<double>(begin: 1.0, end: 1.1).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _pulseAnimation,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _pulseAnimation.value,
+          child: Container(
+            width: 120,
+            height: 120,
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(30),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.white.withOpacity(0.3),
+                  blurRadius: 20 * _pulseAnimation.value,
+                  spreadRadius: 5 * _pulseAnimation.value,
+                ),
               ],
             ),
+            child: const Icon(
+              Icons.water_drop_rounded,
+              size: 64,
+              color: Colors.white,
+            ),
           ),
+        );
+      },
+    );
+  }
+}
+
+// Animated Feature Item
+class _AnimatedFeatureItem extends StatefulWidget {
+  final IconData icon;
+  final String text;
+  final int delay;
+
+  const _AnimatedFeatureItem({
+    required this.icon,
+    required this.text,
+    required this.delay,
+  });
+
+  @override
+  State<_AnimatedFeatureItem> createState() => _AnimatedFeatureItemState();
+}
+
+class _AnimatedFeatureItemState extends State<_AnimatedFeatureItem> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<Offset> _slideAnimation;
+  late Animation<double> _opacityAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(-0.3, 0),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOut,
+    ));
+
+    _opacityAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeIn),
+    );
+
+    Future.delayed(Duration(milliseconds: 600 + widget.delay), () {
+      if (mounted) _controller.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SlideTransition(
+      position: _slideAnimation,
+      child: FadeTransition(
+        opacity: _opacityAnimation,
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.2),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                widget.icon,
+                color: Colors.white,
+                size: 24,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                widget.text,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
-class _FeatureItem extends StatelessWidget {
-  final IconData icon;
-  final String text;
+// Pulsing Button Widget
+class _PulsingButton extends StatefulWidget {
+  final VoidCallback onPressed;
 
-  const _FeatureItem({
-    required this.icon,
-    required this.text,
-  });
+  const _PulsingButton({required this.onPressed});
+
+  @override
+  State<_PulsingButton> createState() => _PulsingButtonState();
+}
+
+class _PulsingButtonState extends State<_PulsingButton> with SingleTickerProviderStateMixin {
+  late AnimationController _pulseController;
+  late Animation<double> _scaleAnimation;
+  bool _isPressed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    )..repeat(reverse: true);
+
+    _scaleAnimation = Tween<double>(begin: 1.0, end: 1.02).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Container(
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            color: Colors.white.withOpacity(0.2),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Icon(
-            icon,
-            color: Colors.white,
-            size: 24,
-          ),
-        ),
-        const SizedBox(width: 16),
-        Expanded(
-          child: Text(
-            text,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 16,
-              fontWeight: FontWeight.w400,
+    return AnimatedBuilder(
+      animation: _scaleAnimation,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _isPressed ? 0.95 : _scaleAnimation.value,
+          child: GestureDetector(
+            onTapDown: (_) => setState(() => _isPressed = true),
+            onTapUp: (_) => setState(() => _isPressed = false),
+            onTapCancel: () => setState(() => _isPressed = false),
+            child: ElevatedButton(
+              onPressed: widget.onPressed,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.white,
+                foregroundColor: Theme.of(context).colorScheme.primary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                elevation: _isPressed ? 2 : 8,
+                shadowColor: Colors.black.withOpacity(0.3),
+              ),
+              child: const Text(
+                'Get Started',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
             ),
           ),
-        ),
-      ],
+        );
+      },
     );
   }
 }

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import '../utils/routes.dart';
+
+class WelcomePage extends StatelessWidget {
+  const WelcomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Theme.of(context).colorScheme.primary,
+              Theme.of(context).colorScheme.secondary,
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Spacer(),
+
+                // App Logo
+                Container(
+                  width: 120,
+                  height: 120,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.2),
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  child: const Icon(
+                    Icons.water_drop_rounded,
+                    size: 64,
+                    color: Colors.white,
+                  ),
+                ),
+
+                const SizedBox(height: 32),
+
+                // App Name
+                const Text(
+                  'DayFlow',
+                  style: TextStyle(
+                    fontSize: 48,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                    letterSpacing: 1.2,
+                  ),
+                ),
+
+                const SizedBox(height: 12),
+
+                // Tagline
+                Text(
+                  'Your Smart Daily Planner',
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Colors.white.withOpacity(0.9),
+                    fontWeight: FontWeight.w300,
+                  ),
+                ),
+
+                const SizedBox(height: 48),
+
+                // Feature List
+                _FeatureItem(
+                  icon: Icons.check_circle_outline,
+                  text: 'Organize your tasks efficiently',
+                ),
+                const SizedBox(height: 16),
+                _FeatureItem(
+                  icon: Icons.note_outlined,
+                  text: 'Capture ideas instantly',
+                ),
+                const SizedBox(height: 16),
+                _FeatureItem(
+                  icon: Icons.alarm_outlined,
+                  text: 'Never miss important reminders',
+                ),
+
+                const Spacer(),
+
+                // Get Started Button
+                SizedBox(
+                  width: double.infinity,
+                  height: 56,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      Routes.navigateToHome(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      foregroundColor: Theme.of(context).colorScheme.primary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      elevation: 0,
+                    ),
+                    child: const Text(
+                      'Get Started',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+
+                // Sign In Link
+                TextButton(
+                  onPressed: () {
+                    // TODO: Navigate to sign in
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Sign in coming soon!')),
+                    );
+                  },
+                  child: const Text(
+                    'Already have an account? Sign In',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureItem extends StatelessWidget {
+  final IconData icon;
+  final String text;
+
+  const _FeatureItem({
+    required this.icon,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(
+            icon,
+            color: Colors.white,
+            size: 24,
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeMode _themeMode = ThemeMode.system;
+
+  ThemeMode get themeMode => _themeMode;
+
+  bool get isDarkMode {
+    if (_themeMode == ThemeMode.system) {
+      return WidgetsBinding.instance.platformDispatcher.platformBrightness == Brightness.dark;
+    }
+    return _themeMode == ThemeMode.dark;
+  }
+
+  void setThemeMode(ThemeMode mode) {
+    _themeMode = mode;
+    notifyListeners();
+  }
+
+  void toggleTheme() {
+    _themeMode = isDarkMode ? ThemeMode.light : ThemeMode.dark;
+    notifyListeners();
+  }
+}
+
+class AppTheme {
+  // Color Schemes
+  static const Color primaryLight = Color(0xFF6366F1); // Indigo
+  static const Color primaryDark = Color(0xFF818CF8);
+  static const Color secondaryLight = Color(0xFF8B5CF6); // Purple
+  static const Color secondaryDark = Color(0xFFA78BFA);
+  static const Color backgroundLight = Color(0xFFF8FAFC);
+  static const Color backgroundDark = Color(0xFF0F172A);
+  static const Color surfaceLight = Color(0xFFFFFFFF);
+  static const Color surfaceDark = Color(0xFF1E293B);
+  static const Color errorColor = Color(0xFFEF4444);
+  static const Color successColor = Color(0xFF10B981);
+
+  // Light Theme
+  static ThemeData lightTheme = ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.light,
+    colorScheme: const ColorScheme.light(
+      primary: primaryLight,
+      secondary: secondaryLight,
+      surface: surfaceLight,
+      error: errorColor,
+    ),
+    scaffoldBackgroundColor: backgroundLight,
+    appBarTheme: const AppBarTheme(
+      elevation: 0,
+      centerTitle: false,
+      backgroundColor: surfaceLight,
+      foregroundColor: Colors.black87,
+      iconTheme: IconThemeData(color: Colors.black87),
+      titleTextStyle: TextStyle(
+        color: Colors.black87,
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+      ),
+    ),
+    bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+      backgroundColor: surfaceLight,
+      selectedItemColor: primaryLight,
+      unselectedItemColor: Colors.black54,
+      elevation: 8,
+      type: BottomNavigationBarType.fixed,
+      selectedLabelStyle: TextStyle(fontWeight: FontWeight.w600),
+    ),
+    drawerTheme: const DrawerThemeData(
+      backgroundColor: surfaceLight,
+      elevation: 8,
+    ),
+    cardTheme: CardThemeData(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      color: surfaceLight,
+    ),
+    floatingActionButtonTheme: const FloatingActionButtonThemeData(
+      backgroundColor: primaryLight,
+      foregroundColor: Colors.white,
+      elevation: 4,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: Colors.grey.shade100,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide.none,
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: primaryLight, width: 2),
+      ),
+    ),
+    textTheme: const TextTheme(
+      headlineLarge: TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: Colors.black87),
+      headlineMedium: TextStyle(fontSize: 24, fontWeight: FontWeight.w600, color: Colors.black87),
+      bodyLarge: TextStyle(fontSize: 16, color: Colors.black87),
+      bodyMedium: TextStyle(fontSize: 14, color: Colors.black87),
+    ),
+  );
+
+  // Dark Theme
+  static ThemeData darkTheme = ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: const ColorScheme.dark(
+      primary: primaryDark,
+      secondary: secondaryDark,
+      surface: surfaceDark,
+      error: errorColor,
+    ),
+    scaffoldBackgroundColor: backgroundDark,
+    appBarTheme: const AppBarTheme(
+      elevation: 0,
+      centerTitle: false,
+      backgroundColor: surfaceDark,
+      foregroundColor: Colors.white,
+      iconTheme: IconThemeData(color: Colors.white),
+      titleTextStyle: TextStyle(
+        color: Colors.white,
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+      ),
+    ),
+    bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+      backgroundColor: surfaceDark,
+      selectedItemColor: primaryDark,
+      unselectedItemColor: Colors.white60,
+      elevation: 8,
+      type: BottomNavigationBarType.fixed,
+      selectedLabelStyle: TextStyle(fontWeight: FontWeight.w600),
+    ),
+    drawerTheme: const DrawerThemeData(
+      backgroundColor: surfaceDark,
+      elevation: 8,
+    ),
+    cardTheme: CardThemeData(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      color: surfaceDark,
+    ),
+    floatingActionButtonTheme: const FloatingActionButtonThemeData(
+      backgroundColor: primaryDark,
+      foregroundColor: backgroundDark,
+      elevation: 4,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: Colors.grey.shade900,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide.none,
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: const BorderSide(color: primaryDark, width: 2),
+      ),
+    ),
+    textTheme: const TextTheme(
+      headlineLarge: TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: Colors.white),
+      headlineMedium: TextStyle(fontSize: 24, fontWeight: FontWeight.w600, color: Colors.white),
+      bodyLarge: TextStyle(fontSize: 16, color: Colors.white),
+      bodyMedium: TextStyle(fontSize: 14, color: Colors.white70),
+    ),
+  );
+}

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import '../widgets/bottom_nav_bar.dart';
+import '../pages/welcome_page.dart';
+import '../pages/todo_page.dart';
+import '../pages/reminders_page.dart';
+import '../pages/habits_page.dart';
+import '../pages/settings_page.dart';
+
+
+
+class Routes {
+  static const String welcome = '/';
+  static const String home = '/home';
+  static const String todo = '/todo';
+  static const String notes = '/notes';
+  static const String reminders = '/reminders';
+  static const String habits = '/habits';
+  static const String settings = '/settings';
+
+  static Map<String, WidgetBuilder> routes = {
+    welcome: (context) => const WelcomePage(),
+    home: (context) => const MainNavigationShell(),
+    todo: (context) => const TodoPage(),
+    reminders: (context) => const RemindersPage(),
+    habits: (context) => const HabitsPage(),
+    settings: (context) => const SettingsPage(),
+
+  };
+
+  static void navigateToHome(BuildContext context) {
+    Navigator.pushReplacementNamed(context, home);
+  }
+
+  static void navigateToWelcome(BuildContext context) {
+    Navigator.pushReplacementNamed(context, welcome);
+  }
+}

--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../theme/app_theme.dart';
+import '../utils/routes.dart';
+
+class AppDrawer extends StatelessWidget {
+  const AppDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
+    final isDark = themeProvider.isDarkMode;
+
+    return Drawer(
+      child: SafeArea(
+        child: Column(
+          children: [
+            // Drawer Header
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: isDark
+                      ? [AppTheme.primaryDark, AppTheme.secondaryDark]
+                      : [AppTheme.primaryLight, AppTheme.secondaryLight],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 64,
+                    height: 64,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.2),
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: const Icon(
+                      Icons.water_drop_rounded,
+                      size: 36,
+                      color: Colors.white,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'DayFlow',
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Your Smart Daily Planner',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.white.withOpacity(0.9),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Drawer Items
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                children: [
+                  _DrawerItem(
+                    icon: Icons.check_circle_outline,
+                    title: 'Tasks',
+                    subtitle: 'Manage your to-dos',
+                    onTap: () {
+                      Navigator.pop(context);
+                      // Navigate to tasks if needed
+                    },
+                  ),
+                  _DrawerItem(
+                    icon: Icons.note_outlined,
+                    title: 'Notes',
+                    subtitle: 'Quick ideas and thoughts',
+                    onTap: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                  _DrawerItem(
+                    icon: Icons.alarm_outlined,
+                    title: 'Reminders',
+                    subtitle: 'Never miss important tasks',
+                    onTap: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                  _DrawerItem(
+                    icon: Icons.track_changes,
+                    title: 'Habits',
+                    subtitle: 'Track your daily habits',
+                    onTap: () {
+                      Navigator.pop(context);
+                      // TODO: Navigate to habits page
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Habits page coming soon!')),
+                      );
+                    },
+                  ),
+                  const Divider(height: 32, indent: 16, endIndent: 16),
+                  _DrawerItem(
+                    icon: Icons.bar_chart_rounded,
+                    title: 'Statistics',
+                    subtitle: 'View your progress',
+                    onTap: () {
+                      Navigator.pop(context);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Statistics coming soon!')),
+                      );
+                    },
+                  ),
+                  _DrawerItem(
+                    icon: Icons.settings_outlined,
+                    title: 'Settings',
+                    subtitle: 'Customize your experience',
+                    onTap: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                ],
+              ),
+            ),
+
+            // Bottom Section
+            const Divider(height: 1),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  // Theme Toggle
+                  ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+                    leading: Icon(
+                      isDark ? Icons.dark_mode : Icons.light_mode,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    title: const Text('Theme'),
+                    trailing: Switch(
+                      value: isDark,
+                      onChanged: (value) {
+                        themeProvider.toggleTheme();
+                      },
+                    ),
+                  ),
+
+                  // Logout Button
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        _showLogoutDialog(context);
+                      },
+                      icon: const Icon(Icons.logout),
+                      label: const Text('Logout'),
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showLogoutDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Logout'),
+        content: const Text('Are you sure you want to logout?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.pop(context);
+              Navigator.pop(context); // Close drawer
+              Routes.navigateToWelcome(context);
+            },
+            child: const Text('Logout'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DrawerItem extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  const _DrawerItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          icon,
+          color: Theme.of(context).colorScheme.primary,
+          size: 24,
+        ),
+      ),
+      title: Text(
+        title,
+        style: const TextStyle(
+          fontWeight: FontWeight.w600,
+          fontSize: 16,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(
+          fontSize: 12,
+          color: Theme.of(context).textTheme.bodyMedium?.color?.withOpacity(0.7),
+        ),
+      ),
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    );
+  }
+}

--- a/lib/widgets/bottom_nav_bar.dart
+++ b/lib/widgets/bottom_nav_bar.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import '../pages/todo_page.dart';
+import '../pages/notes_page.dart';
+import '../pages/reminders_page.dart';
+import '../pages/settings_page.dart';
+import 'app_drawer.dart';
+import '../pages/habits_page.dart';
+
+class MainNavigationShell extends StatefulWidget {
+  const MainNavigationShell({super.key});
+
+  @override
+  State<MainNavigationShell> createState() => _MainNavigationShellState();
+}
+
+class _MainNavigationShellState extends State<MainNavigationShell> {
+  int _currentIndex = 0;
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  // Page titles for AppBar
+  final List<String> _pageTitles = [
+    'Tasks',
+    'Notes',
+    'Reminders',
+    'Habits',
+    'Settings',
+  ];
+
+  // Pages corresponding to bottom nav items
+  final List<Widget> _pages = [
+    const TodoPage(),
+    const NotesPage(),
+    const RemindersPage(),
+    const HabitsPage(),
+    const SettingsPage(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: _scaffoldKey,
+      appBar: AppBar(
+        title: Text(_pageTitles[_currentIndex]),
+        leading: IconButton(
+          icon: const Icon(Icons.menu),
+          onPressed: () {
+            _scaffoldKey.currentState?.openDrawer();
+          },
+          tooltip: 'Open menu',
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {
+              // TODO: Implement search functionality
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Search feature coming soon!')),
+              );
+            },
+            tooltip: 'Search',
+          ),
+          IconButton(
+            icon: const Icon(Icons.notifications_outlined),
+            onPressed: () {
+              // TODO: Implement notifications
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('No new notifications')),
+              );
+            },
+            tooltip: 'Notifications',
+          ),
+        ],
+      ),
+      drawer: const AppDrawer(),
+      body: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        child: _pages[_currentIndex],
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.check_circle_outline),
+            activeIcon: Icon(Icons.check_circle),
+            label: 'Tasks',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.note_outlined),
+            activeIcon: Icon(Icons.note),
+            label: 'Notes',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.alarm_outlined),
+            activeIcon: Icon(Icons.alarm),
+            label: 'Reminders',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.track_changes_outlined),
+            activeIcon: Icon(Icons.track_changes),
+            label: 'Habits',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings_outlined),
+            activeIcon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_button.dart
+++ b/lib/widgets/custom_button.dart
@@ -1,0 +1,232 @@
+// Button components
+
+import 'package:flutter/material.dart';
+
+enum ButtonType { primary, secondary, outlined, text }
+
+enum ButtonSize { small, medium, large }
+
+class CustomButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final ButtonType type;
+  final ButtonSize size;
+  final IconData? icon;
+  final bool isLoading;
+  final double? width;
+
+  const CustomButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.type = ButtonType.primary,
+    this.size = ButtonSize.medium,
+    this.icon,
+    this.isLoading = false,
+    this.width,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDisabled = onPressed == null || isLoading;
+
+    // Size configurations
+    double height;
+    double fontSize;
+    double iconSize;
+    EdgeInsets padding;
+
+    switch (size) {
+      case ButtonSize.small:
+        height = 36;
+        fontSize = 14;
+        iconSize = 18;
+        padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
+        break;
+      case ButtonSize.medium:
+        height = 44;
+        fontSize = 16;
+        iconSize = 20;
+        padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 12);
+        break;
+      case ButtonSize.large:
+        height = 52;
+        fontSize = 18;
+        iconSize = 22;
+        padding = const EdgeInsets.symmetric(horizontal: 20, vertical: 14);
+        break;
+    }
+
+    Widget buttonChild = isLoading
+        ? SizedBox(
+      width: iconSize,
+      height: iconSize,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        valueColor: AlwaysStoppedAnimation<Color>(
+          type == ButtonType.primary
+              ? Colors.white
+              : theme.colorScheme.primary,
+        ),
+      ),
+    )
+        : Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        if (icon != null) ...[
+          Icon(icon, size: iconSize),
+          const SizedBox(width: 8),
+        ],
+        Text(
+          text,
+          style: TextStyle(
+            fontSize: fontSize,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+
+    Widget button;
+
+    switch (type) {
+      case ButtonType.primary:
+        button = ElevatedButton(
+          onPressed: isDisabled ? null : onPressed,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: theme.colorScheme.primary,
+            foregroundColor: Colors.white,
+            disabledBackgroundColor: theme.colorScheme.primary.withOpacity(0.5),
+            disabledForegroundColor: Colors.white.withOpacity(0.6),
+            padding: padding,
+            minimumSize: Size(width ?? 0, height),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            elevation: isDisabled ? 0 : 2,
+          ),
+          child: buttonChild,
+        );
+        break;
+
+      case ButtonType.secondary:
+        button = ElevatedButton(
+          onPressed: isDisabled ? null : onPressed,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: theme.colorScheme.secondary,
+            foregroundColor: Colors.white,
+            disabledBackgroundColor: theme.colorScheme.secondary.withOpacity(0.5),
+            disabledForegroundColor: Colors.white.withOpacity(0.6),
+            padding: padding,
+            minimumSize: Size(width ?? 0, height),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            elevation: isDisabled ? 0 : 2,
+          ),
+          child: buttonChild,
+        );
+        break;
+
+      case ButtonType.outlined:
+        button = OutlinedButton(
+          onPressed: isDisabled ? null : onPressed,
+          style: OutlinedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            disabledForegroundColor: theme.colorScheme.primary.withOpacity(0.5),
+            padding: padding,
+            minimumSize: Size(width ?? 0, height),
+            side: BorderSide(
+              color: isDisabled
+                  ? theme.colorScheme.primary.withOpacity(0.3)
+                  : theme.colorScheme.primary,
+              width: 2,
+            ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          child: buttonChild,
+        );
+        break;
+
+      case ButtonType.text:
+        button = TextButton(
+          onPressed: isDisabled ? null : onPressed,
+          style: TextButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            disabledForegroundColor: theme.colorScheme.primary.withOpacity(0.5),
+            padding: padding,
+            minimumSize: Size(width ?? 0, height),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+          child: buttonChild,
+        );
+        break;
+    }
+
+    return SizedBox(
+      width: width,
+      child: button,
+    );
+  }
+}
+
+// Icon Button Component
+class CustomIconButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final Color? color;
+  final Color? backgroundColor;
+  final double size;
+  final String? tooltip;
+
+  const CustomIconButton({
+    super.key,
+    required this.icon,
+    this.onPressed,
+    this.color,
+    this.backgroundColor,
+    this.size = 40,
+    this.tooltip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final button = Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: backgroundColor ??
+            (onPressed == null
+                ? theme.colorScheme.primary.withOpacity(0.1)
+                : theme.colorScheme.primary.withOpacity(0.1)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: IconButton(
+        icon: Icon(icon),
+        onPressed: onPressed,
+        color: color ??
+            (onPressed == null
+                ? theme.colorScheme.primary.withOpacity(0.5)
+                : theme.colorScheme.primary),
+        iconSize: size * 0.5,
+        padding: EdgeInsets.zero,
+      ),
+    );
+
+    if (tooltip != null) {
+      return Tooltip(
+        message: tooltip!,
+        child: button,
+      );
+    }
+
+    return button;
+  }
+}

--- a/lib/widgets/custom_card.dart
+++ b/lib/widgets/custom_card.dart
@@ -1,0 +1,201 @@
+// Card components
+
+import 'package:flutter/material.dart';
+
+class CustomCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+  final Color? color;
+  final double? elevation;
+  final VoidCallback? onTap;
+  final BorderRadius? borderRadius;
+  final Border? border;
+
+  const CustomCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.margin,
+    this.color,
+    this.elevation,
+    this.onTap,
+    this.borderRadius,
+    this.border,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cardColor = color ?? theme.cardTheme.color ?? theme.colorScheme.surface;
+
+    Widget card = Container(
+      margin: margin ?? const EdgeInsets.symmetric(vertical: 8, horizontal: 0),
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: borderRadius ?? BorderRadius.circular(12),
+        border: border,
+        boxShadow: elevation != null && elevation! > 0
+            ? [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: elevation! * 2,
+            offset: Offset(0, elevation! / 2),
+          ),
+        ]
+            : null,
+      ),
+      child: Padding(
+        padding: padding ?? const EdgeInsets.all(16),
+        child: child,
+      ),
+    );
+
+    if (onTap != null) {
+      return Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: borderRadius ?? BorderRadius.circular(12),
+          child: card,
+        ),
+      );
+    }
+
+    return card;
+  }
+}
+
+// Info Card with Icon
+class InfoCard extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final IconData icon;
+  final Color? iconColor;
+  final Color? backgroundColor;
+  final VoidCallback? onTap;
+
+  const InfoCard({
+    super.key,
+    required this.title,
+    this.subtitle,
+    required this.icon,
+    this.iconColor,
+    this.backgroundColor,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cardIconColor = iconColor ?? theme.colorScheme.primary;
+    final cardBgColor = backgroundColor ?? cardIconColor.withOpacity(0.1);
+
+    return CustomCard(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: cardBgColor,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(
+              icon,
+              color: cardIconColor,
+              size: 24,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    subtitle!,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (onTap != null)
+            Icon(
+              Icons.chevron_right,
+              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// Stat Card
+class StatCard extends StatelessWidget {
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color? color;
+
+  const StatCard({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.icon,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final statColor = color ?? theme.colorScheme.primary;
+
+    return CustomCard(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: statColor.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              icon,
+              color: statColor,
+              size: 24,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            value,
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: statColor,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_input.dart
+++ b/lib/widgets/custom_input.dart
@@ -1,0 +1,272 @@
+// Input field components
+
+import 'package:flutter/material.dart';
+
+enum InputType { text, password, email, number, multiline, search }
+
+class CustomInput extends StatefulWidget {
+  final String? label;
+  final String? hint;
+  final String? initialValue;
+  final InputType type;
+  final TextEditingController? controller;
+  final String? Function(String?)? validator;
+  final void Function(String)? onChanged;
+  final void Function(String)? onSubmitted;
+  final IconData? prefixIcon;
+  final IconData? suffixIcon;
+  final VoidCallback? onSuffixIconPressed;
+  final bool enabled;
+  final int? maxLines;
+  final int? maxLength;
+  final TextInputAction? textInputAction;
+  final FocusNode? focusNode;
+
+  const CustomInput({
+    super.key,
+    this.label,
+    this.hint,
+    this.initialValue,
+    this.type = InputType.text,
+    this.controller,
+    this.validator,
+    this.onChanged,
+    this.onSubmitted,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.onSuffixIconPressed,
+    this.enabled = true,
+    this.maxLines,
+    this.maxLength,
+    this.textInputAction,
+    this.focusNode,
+  });
+
+  @override
+  State<CustomInput> createState() => _CustomInputState();
+}
+
+class _CustomInputState extends State<CustomInput> {
+  bool _obscureText = true;
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Configure input based on type
+    TextInputType keyboardType;
+    int? maxLines = widget.maxLines;
+    bool obscureText = false;
+    IconData? suffixIcon = widget.suffixIcon;
+    VoidCallback? suffixIconPressed = widget.onSuffixIconPressed;
+
+    switch (widget.type) {
+      case InputType.password:
+        keyboardType = TextInputType.visiblePassword;
+        obscureText = _obscureText;
+        suffixIcon = _obscureText ? Icons.visibility_off : Icons.visibility;
+        suffixIconPressed = () {
+          setState(() {
+            _obscureText = !_obscureText;
+          });
+        };
+        maxLines = 1;
+        break;
+      case InputType.email:
+        keyboardType = TextInputType.emailAddress;
+        maxLines = 1;
+        break;
+      case InputType.number:
+        keyboardType = TextInputType.number;
+        maxLines = 1;
+        break;
+      case InputType.multiline:
+        keyboardType = TextInputType.multiline;
+        maxLines ??= 5;
+        break;
+      case InputType.search:
+        keyboardType = TextInputType.text;
+        maxLines = 1;
+        break;
+      default:
+        keyboardType = TextInputType.text;
+        maxLines ??= 1;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: theme.brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        TextFormField(
+          controller: _controller,
+          focusNode: widget.focusNode,
+          enabled: widget.enabled,
+          obscureText: obscureText,
+          keyboardType: keyboardType,
+          maxLines: maxLines,
+          maxLength: widget.maxLength,
+          textInputAction: widget.textInputAction,
+          validator: widget.validator,
+          onChanged: widget.onChanged,
+          onFieldSubmitted: widget.onSubmitted,
+          style: theme.textTheme.bodyLarge,
+          decoration: InputDecoration(
+            hintText: widget.hint,
+            hintStyle: TextStyle(
+              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+            ),
+            prefixIcon: widget.prefixIcon != null
+                ? Icon(widget.prefixIcon, color: theme.colorScheme.primary)
+                : null,
+            suffixIcon: suffixIcon != null
+                ? IconButton(
+              icon: Icon(suffixIcon),
+              onPressed: suffixIconPressed,
+              color: theme.colorScheme.primary,
+            )
+                : null,
+            filled: true,
+            fillColor: theme.brightness == Brightness.dark
+                ? Colors.grey.shade900
+                : Colors.grey.shade100,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: theme.colorScheme.primary,
+                width: 2,
+              ),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: theme.colorScheme.error,
+                width: 2,
+              ),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(
+                color: theme.colorScheme.error,
+                width: 2,
+              ),
+            ),
+            disabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 16,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// Search Input Component
+class SearchInput extends StatelessWidget {
+  final TextEditingController? controller;
+  final String? hint;
+  final void Function(String)? onChanged;
+  final void Function(String)? onSubmitted;
+  final VoidCallback? onClear;
+
+  const SearchInput({
+    super.key,
+    this.controller,
+    this.hint,
+    this.onChanged,
+    this.onSubmitted,
+    this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textController = controller ?? TextEditingController();
+
+    return TextField(
+      controller: textController,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      style: theme.textTheme.bodyLarge,
+      decoration: InputDecoration(
+        hintText: hint ?? 'Search...',
+        hintStyle: TextStyle(
+          color: theme.textTheme.bodyMedium?.color?.withOpacity(0.5),
+        ),
+        prefixIcon: Icon(Icons.search, color: theme.colorScheme.primary),
+        suffixIcon: textController.text.isNotEmpty
+            ? IconButton(
+          icon: const Icon(Icons.clear),
+          onPressed: () {
+            textController.clear();
+            if (onClear != null) onClear!();
+            if (onChanged != null) onChanged!('');
+          },
+          color: theme.colorScheme.primary,
+        )
+            : null,
+        filled: true,
+        fillColor: theme.brightness == Brightness.dark
+            ? Colors.grey.shade900
+            : Colors.grey.shade100,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide.none,
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(
+            color: theme.colorScheme.primary,
+            width: 2,
+          ),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/date_time_picker.dart
+++ b/lib/widgets/date_time_picker.dart
@@ -1,0 +1,493 @@
+import 'package:flutter/material.dart' as material;
+// as material to avoid conflict with showDatePicker build-in class
+import 'package:flutter/material.dart';
+
+class DateTimePicker {
+  // Show custom styled date picker
+  static Future<DateTime?> showDatePicker({
+    required BuildContext context,
+    DateTime? initialDate,
+    DateTime? firstDate,
+    DateTime? lastDate,
+    String? helpText,
+  }) async {
+    final theme = Theme.of(context);
+
+    return await material.showDatePicker(
+      context: context,
+      initialDate: initialDate ?? DateTime.now(),
+      firstDate: firstDate ?? DateTime(2020),
+      lastDate: lastDate ?? DateTime(2030),
+      helpText: helpText ?? 'Select Date',
+      builder: (context, child) {
+        return Theme(
+          data: theme.copyWith(
+            colorScheme: theme.colorScheme.copyWith(
+              primary: theme.colorScheme.primary,
+              onPrimary: Colors.white,
+              surface: theme.colorScheme.surface,
+              onSurface: theme.textTheme.bodyLarge?.color ?? Colors.black,
+            ),
+            dialogBackgroundColor: theme.colorScheme.surface,
+          ),
+          child: child!,
+        );
+      },
+    );
+  }
+
+  // Show custom styled time picker
+  static Future<TimeOfDay?> showTimePicker({
+    required BuildContext context,
+    TimeOfDay? initialTime,
+    String? helpText,
+  }) async {
+    final theme = Theme.of(context);
+
+    return await material.showTimePicker(
+      context: context,
+      initialTime: initialTime ?? TimeOfDay.now(),
+      helpText: helpText ?? 'Select Time',
+      builder: (context, child) {
+        return Theme(
+          data: theme.copyWith(
+            colorScheme: theme.colorScheme.copyWith(
+              primary: theme.colorScheme.primary,
+              onPrimary: Colors.white,
+              surface: theme.colorScheme.surface,
+              onSurface: theme.textTheme.bodyLarge?.color ?? Colors.black,
+            ),
+            dialogBackgroundColor: theme.colorScheme.surface,
+          ),
+          child: child!,
+        );
+      },
+    );
+  }
+
+  // Show combined date and time picker
+  static Future<DateTime?> showDateTimePicker({
+    required BuildContext context,
+    DateTime? initialDateTime,
+  }) async {
+    final date = await DateTimePicker.showDatePicker(
+      context: context,
+      initialDate: initialDateTime,
+    );
+
+    if (date == null) return null;
+
+    if (!context.mounted) return null;
+
+    final time = await DateTimePicker.showTimePicker(
+      context: context,
+      initialTime: initialDateTime != null
+          ? TimeOfDay.fromDateTime(initialDateTime)
+          : null,
+    );
+
+    if (time == null) return null;
+
+    return DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute,
+    );
+  }
+}
+
+// Date picker input field
+class DatePickerField extends StatefulWidget {
+  final String? label;
+  final DateTime? initialDate;
+  final DateTime? firstDate;
+  final DateTime? lastDate;
+  final void Function(DateTime?)? onChanged;
+  final String? hint;
+  final bool enabled;
+  final IconData? prefixIcon;
+
+  const DatePickerField({
+    super.key,
+    this.label,
+    this.initialDate,
+    this.firstDate,
+    this.lastDate,
+    this.onChanged,
+    this.hint,
+    this.enabled = true,
+    this.prefixIcon,
+  });
+
+  @override
+  State<DatePickerField> createState() => _DatePickerFieldState();
+}
+
+class _DatePickerFieldState extends State<DatePickerField> {
+  DateTime? _selectedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate = widget.initialDate;
+  }
+
+  String _formatDate(DateTime date) {
+    final months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    ];
+    return '${months[date.month - 1]} ${date.day}, ${date.year}';
+  }
+
+  Future<void> _selectDate() async {
+    final date = await DateTimePicker.showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: widget.firstDate,
+      lastDate: widget.lastDate,
+    );
+
+    if (date != null) {
+      setState(() {
+        _selectedDate = date;
+      });
+      if (widget.onChanged != null) {
+        widget.onChanged!(date);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: theme.brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        InkWell(
+          onTap: widget.enabled ? _selectDate : null,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            decoration: BoxDecoration(
+              color: theme.brightness == Brightness.dark
+                  ? Colors.grey.shade900
+                  : Colors.grey.shade100,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Colors.transparent,
+                width: 2,
+              ),
+            ),
+            child: Row(
+              children: [
+                if (widget.prefixIcon != null) ...[
+                  Icon(
+                    widget.prefixIcon,
+                    color: theme.colorScheme.primary,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Text(
+                    _selectedDate != null
+                        ? _formatDate(_selectedDate!)
+                        : widget.hint ?? 'Select date',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: _selectedDate != null
+                          ? theme.textTheme.bodyLarge?.color
+                          : theme.textTheme.bodyMedium?.color
+                          ?.withOpacity(0.5),
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.calendar_today,
+                  color: theme.colorScheme.primary,
+                  size: 20,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// Time picker input field
+class TimePickerField extends StatefulWidget {
+  final String? label;
+  final TimeOfDay? initialTime;
+  final void Function(TimeOfDay?)? onChanged;
+  final String? hint;
+  final bool enabled;
+  final IconData? prefixIcon;
+
+  const TimePickerField({
+    super.key,
+    this.label,
+    this.initialTime,
+    this.onChanged,
+    this.hint,
+    this.enabled = true,
+    this.prefixIcon,
+  });
+
+  @override
+  State<TimePickerField> createState() => _TimePickerFieldState();
+}
+
+class _TimePickerFieldState extends State<TimePickerField> {
+  TimeOfDay? _selectedTime;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedTime = widget.initialTime;
+  }
+
+  String _formatTime(TimeOfDay time) {
+    final hour = time.hourOfPeriod == 0 ? 12 : time.hourOfPeriod;
+    final minute = time.minute.toString().padLeft(2, '0');
+    final period = time.period == DayPeriod.am ? 'AM' : 'PM';
+    return '$hour:$minute $period';
+  }
+
+  Future<void> _selectTime() async {
+    final time = await DateTimePicker.showTimePicker(
+      context: context,
+      initialTime: _selectedTime,
+    );
+
+    if (time != null) {
+      setState(() {
+        _selectedTime = time;
+      });
+      if (widget.onChanged != null) {
+        widget.onChanged!(time);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: theme.brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        InkWell(
+          onTap: widget.enabled ? _selectTime : null,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            decoration: BoxDecoration(
+              color: theme.brightness == Brightness.dark
+                  ? Colors.grey.shade900
+                  : Colors.grey.shade100,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Colors.transparent,
+                width: 2,
+              ),
+            ),
+            child: Row(
+              children: [
+                if (widget.prefixIcon != null) ...[
+                  Icon(
+                    widget.prefixIcon,
+                    color: theme.colorScheme.primary,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Text(
+                    _selectedTime != null
+                        ? _formatTime(_selectedTime!)
+                        : widget.hint ?? 'Select time',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: _selectedTime != null
+                          ? theme.textTheme.bodyLarge?.color
+                          : theme.textTheme.bodyMedium?.color
+                          ?.withOpacity(0.5),
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.access_time,
+                  color: theme.colorScheme.primary,
+                  size: 20,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// DateTime picker input field (combined date and time)
+class DateTimePickerField extends StatefulWidget {
+  final String? label;
+  final DateTime? initialDateTime;
+  final DateTime? firstDate;
+  final DateTime? lastDate;
+  final void Function(DateTime?)? onChanged;
+  final String? hint;
+  final bool enabled;
+  final IconData? prefixIcon;
+
+  const DateTimePickerField({
+    super.key,
+    this.label,
+    this.initialDateTime,
+    this.firstDate,
+    this.lastDate,
+    this.onChanged,
+    this.hint,
+    this.enabled = true,
+    this.prefixIcon,
+  });
+
+  @override
+  State<DateTimePickerField> createState() => _DateTimePickerFieldState();
+}
+
+class _DateTimePickerFieldState extends State<DateTimePickerField> {
+  DateTime? _selectedDateTime;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDateTime = widget.initialDateTime;
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    ];
+    final hour = dateTime.hour > 12 ? dateTime.hour - 12 : (dateTime.hour == 0 ? 12 : dateTime.hour);
+    final minute = dateTime.minute.toString().padLeft(2, '0');
+    final period = dateTime.hour >= 12 ? 'PM' : 'AM';
+
+    return '${months[dateTime.month - 1]} ${dateTime.day}, ${dateTime.year} at $hour:$minute $period';
+  }
+
+  Future<void> _selectDateTime() async {
+    final dateTime = await DateTimePicker.showDateTimePicker(
+      context: context,
+      initialDateTime: _selectedDateTime,
+    );
+
+    if (dateTime != null) {
+      setState(() {
+        _selectedDateTime = dateTime;
+      });
+      if (widget.onChanged != null) {
+        widget.onChanged!(dateTime);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: theme.brightness == Brightness.dark
+                  ? Colors.white
+                  : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        InkWell(
+          onTap: widget.enabled ? _selectDateTime : null,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            decoration: BoxDecoration(
+              color: theme.brightness == Brightness.dark
+                  ? Colors.grey.shade900
+                  : Colors.grey.shade100,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: Colors.transparent,
+                width: 2,
+              ),
+            ),
+            child: Row(
+              children: [
+                if (widget.prefixIcon != null) ...[
+                  Icon(
+                    widget.prefixIcon,
+                    color: theme.colorScheme.primary,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Text(
+                    _selectedDateTime != null
+                        ? _formatDateTime(_selectedDateTime!)
+                        : widget.hint ?? 'Select date and time',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: _selectedDateTime != null
+                          ? theme.textTheme.bodyLarge?.color
+                          : theme.textTheme.bodyMedium?.color
+                          ?.withOpacity(0.5),
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.event,
+                  color: theme.colorScheme.primary,
+                  size: 20,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/dayflow_ui_kit_demo.md
+++ b/lib/widgets/dayflow_ui_kit_demo.md
@@ -1,0 +1,1008 @@
+# Shared UI Kit & Components Implementation Guide
+
+##  Implementation Complete
+
+A complete, reusable UI component library for the DayFlow app with:
+
+- Custom buttons (primary, secondary, outlined, text, icon)
+- Input fields (text, password, email, number, multiline, search)
+- Card components (basic, info, stat)
+- TaskItem with priority, due dates, and actions
+- NoteItem with tags, pins, and timestamps
+- Modal bottom sheets (basic, form, list, confirmation)
+- Date/Time picker wrappers with custom styling
+- Consistent theming across all components
+
+---
+
+##  File Structure
+
+```
+lib/widgets/
+├── ui_kit.dart                    # Central export file
+├── custom_button.dart             # Button components
+├── custom_input.dart              # Input field components
+├── custom_card.dart               # Card components
+├── task_item.dart                 # Task display widget
+├── note_item.dart                 # Note display widget
+├── modal_sheet.dart               # Modal bottom sheet components
+└── date_time_picker.dart          # Date/Time picker wrappers
+```
+
+---
+
+##  Quick Start
+
+### Import the UI Kit
+
+```dart
+import 'package:dayflow/widgets/ui_kit.dart';
+```
+
+This single import gives you access to all UI components!
+
+---
+
+## Component Documentation
+
+### 1. Buttons
+
+#### CustomButton
+Full-featured button with multiple variants and states.
+
+```dart
+// Primary button
+CustomButton(
+  text: 'Save Task',
+  type: ButtonType.primary,
+  size: ButtonSize.large,
+  icon: Icons.save,
+  onPressed: () {
+    // Your action
+  },
+);
+
+// Secondary button
+CustomButton(
+  text: 'Archive',
+  type: ButtonType.secondary,
+  onPressed: () {},
+);
+
+// Outlined button
+CustomButton(
+  text: 'Cancel',
+  type: ButtonType.outlined,
+  onPressed: () {},
+);
+
+// Text button
+CustomButton(
+  text: 'Skip',
+  type: ButtonType.text,
+  onPressed: () {},
+);
+
+// Loading state
+CustomButton(
+  text: 'Saving...',
+  isLoading: true,
+  onPressed: () {},
+);
+
+// Disabled state
+CustomButton(
+  text: 'Submit',
+  onPressed: null, // null makes it disabled
+);
+```
+
+**Properties:**
+- `text` (required): Button label
+- `onPressed`: Callback function
+- `type`: ButtonType.primary | secondary | outlined | text
+- `size`: ButtonSize.small | medium | large
+- `icon`: Optional icon
+- `isLoading`: Shows loading spinner
+- `width`: Custom width (default: auto)
+
+#### CustomIconButton
+Compact icon button with tooltip support.
+
+```dart
+CustomIconButton(
+  icon: Icons.edit,
+  onPressed: () {},
+  tooltip: 'Edit',
+  color: Colors.blue,
+  size: 48,
+);
+```
+
+---
+
+### 2. Input Fields
+
+#### CustomInput
+Versatile input field with multiple types and validation.
+
+```dart
+// Text input
+CustomInput(
+  label: 'Task Title',
+  hint: 'Enter task title',
+  type: InputType.text,
+  prefixIcon: Icons.task,
+  controller: _titleController,
+  onChanged: (value) {
+    print('Changed: $value');
+  },
+  validator: (value) {
+    if (value == null || value.isEmpty) {
+      return 'Title is required';
+    }
+    return null;
+  },
+);
+
+// Password input (with show/hide toggle)
+CustomInput(
+  label: 'Password',
+  type: InputType.password,
+  prefixIcon: Icons.lock,
+);
+
+// Email input
+CustomInput(
+  label: 'Email',
+  type: InputType.email,
+  prefixIcon: Icons.email,
+);
+
+// Multiline input
+CustomInput(
+  label: 'Description',
+  type: InputType.multiline,
+  maxLines: 5,
+);
+
+// With character limit
+CustomInput(
+  label: 'Title',
+  maxLength: 50,
+);
+```
+
+**Input Types:**
+- `InputType.text`: Standard text
+- `InputType.password`: Auto-hide with toggle
+- `InputType.email`: Email keyboard
+- `InputType.number`: Numeric keyboard
+- `InputType.multiline`: Multi-line text area
+- `InputType.search`: Search field
+
+#### SearchInput
+Dedicated search field with clear button.
+
+```dart
+SearchInput(
+  hint: 'Search tasks...',
+  controller: _searchController,
+  onChanged: (value) {
+    // Perform search
+  },
+  onClear: () {
+    // Handle clear
+  },
+);
+```
+
+---
+
+### 3. Cards
+
+#### CustomCard
+Basic card container with tap support.
+
+```dart
+CustomCard(
+  padding: EdgeInsets.all(20),
+  margin: EdgeInsets.symmetric(vertical: 8),
+  elevation: 2,
+  onTap: () {
+    // Card tapped
+  },
+  child: Column(
+    children: [
+      Text('Card Title'),
+      Text('Card content...'),
+    ],
+  ),
+);
+```
+
+#### InfoCard
+Card with icon, title, and subtitle.
+
+```dart
+InfoCard(
+  title: 'Productivity Tips',
+  subtitle: 'Learn how to be more efficient',
+  icon: Icons.lightbulb,
+  iconColor: Colors.amber,
+  onTap: () {},
+);
+```
+
+#### StatCard
+Display statistics with icon and value.
+
+```dart
+StatCard(
+  label: 'Completed Tasks',
+  value: '24',
+  icon: Icons.check_circle,
+  color: Colors.green,
+);
+```
+
+---
+
+### 4. TaskItem
+
+Complete task display with priority, due dates, and actions.
+
+```dart
+TaskItem(
+  title: 'Complete project documentation',
+  description: 'Write comprehensive docs for the new API',
+  isCompleted: false,
+  priority: TaskPriority.high,
+  dueDate: DateTime.now().add(Duration(days: 2)),
+  category: 'Work',
+  onTap: () {
+    // View task details
+  },
+  onToggleComplete: () {
+    // Toggle completion
+  },
+  onEdit: () {
+    // Edit task
+  },
+  onDelete: () {
+    // Delete task
+  },
+);
+```
+
+**Features:**
+- Checkbox for completion status
+- Priority badges (low, medium, high) with colors
+- Due date display with "Today", "Tomorrow", "Overdue"
+- Category tags
+- Action menu (edit, delete)
+- Strike-through for completed tasks
+- Visual indicators for overdue tasks
+
+**Priority Levels:**
+- `TaskPriority.low` - Green badge
+- `TaskPriority.medium` - Orange badge
+- `TaskPriority.high` - Red badge
+
+---
+
+### 5. NoteItem
+
+Note display with tags, pins, and timestamps.
+
+```dart
+NoteItem(
+  title: 'Meeting Notes - Q4 Planning',
+  content: 'Discussed project timeline, resource allocation...',
+  createdAt: DateTime.now().subtract(Duration(hours: 2)),
+  updatedAt: DateTime.now(),
+  color: Colors.blue,
+  tags: ['work', 'meeting', 'important'],
+  isPinned: true,
+  onTap: () {
+    // View note
+  },
+  onEdit: () {},
+  onDelete: () {},
+  onPin: () {
+    // Toggle pin
+  },
+);
+```
+
+**Features:**
+- Left border with custom color
+- Pin indicator
+- Content preview (3 lines max)
+- Tag display (up to 3 tags)
+- Relative timestamps ("2h ago", "Yesterday")
+- Action menu (pin, edit, delete)
+
+#### NoteItemCompact
+Compact version for grid layouts.
+
+```dart
+NoteItemCompact(
+  title: 'Quick Idea',
+  content: 'Build a feature for task templates...',
+  color: Colors.purple.withOpacity(0.2),
+  onTap: () {},
+);
+```
+
+---
+
+### 6. Modal Bottom Sheets
+
+#### Basic Modal
+```dart
+CustomModalSheet.show(
+  context: context,
+  title: 'Add New Task',
+  child: Column(
+    children: [
+      CustomInput(label: 'Title', hint: 'Enter title'),
+      SizedBox(height: 16),
+      CustomButton(
+        text: 'Create',
+        onPressed: () {
+          // Save and close
+          Navigator.pop(context);
+        },
+      ),
+    ],
+  ),
+);
+```
+
+#### Form Modal
+```dart
+final result = await CustomModalSheet.showForm(
+  context: context,
+  title: 'Edit Task',
+  child: Column(
+    children: [
+      CustomInput(label: 'Title', controller: titleController),
+      SizedBox(height: 16),
+      CustomInput(label: 'Description', type: InputType.multiline),
+    ],
+  ),
+  confirmText: 'Save Changes',
+  cancelText: 'Discard',
+  onConfirm: () {
+    // Save changes
+  },
+);
+
+if (result == true) {
+  // User confirmed
+}
+```
+
+#### List Selection Modal
+```dart
+final selectedPriority = await CustomModalSheet.showListSelection<TaskPriority>(
+  context: context,
+  title: 'Select Priority',
+  items: TaskPriority.values,
+  itemBuilder: (priority) => priority.name.toUpperCase(),
+  iconBuilder: (priority) => Icons.flag,
+  selectedItem: currentPriority,
+);
+
+if (selectedPriority != null) {
+  // Use selected priority
+}
+```
+
+#### Confirmation Modal
+```dart
+final confirmed = await CustomModalSheet.showConfirmation(
+  context: context,
+  title: 'Delete Task',
+  message: 'This action cannot be undone. Are you sure?',
+  confirmText: 'Delete',
+  cancelText: 'Cancel',
+  isDangerous: true,
+);
+
+if (confirmed == true) {
+  // Delete task
+}
+```
+
+#### Quick Action Sheet
+```dart
+QuickActionSheet.show(
+  context: context,
+  title: 'Quick Actions',
+  actions: [
+    QuickAction(
+      title: 'Add Task',
+      subtitle: 'Create a new task',
+      icon: Icons.add_task,
+      color: Colors.blue,
+      onTap: () {
+        // Add task logic
+      },
+    ),
+    QuickAction(
+      title: 'Add Note',
+      subtitle: 'Jot down a quick note',
+      icon: Icons.note_add,
+      color: Colors.purple,
+      onTap: () {
+        // Add note logic
+      },
+    ),
+  ],
+);
+```
+
+---
+
+### 7. Date/Time Pickers
+
+#### DatePickerField
+```dart
+DatePickerField(
+  label: 'Due Date',
+  hint: 'Select due date',
+  prefixIcon: Icons.calendar_today,
+  initialDate: DateTime.now(),
+  firstDate: DateTime.now(),
+  lastDate: DateTime.now().add(Duration(days: 365)),
+  onChanged: (date) {
+    print('Selected date: $date');
+  },
+);
+```
+
+#### TimePickerField
+```dart
+TimePickerField(
+  label: 'Reminder Time',
+  hint: 'Select time',
+  prefixIcon: Icons.access_time,
+  initialTime: TimeOfDay.now(),
+  onChanged: (time) {
+    print('Selected time: $time');
+  },
+);
+```
+
+#### DateTimePickerField
+```dart
+DateTimePickerField(
+  label: 'Deadline',
+  hint: 'Select date and time',
+  prefixIcon: Icons.event,
+  initialDateTime: DateTime.now(),
+  onChanged: (dateTime) {
+    print('Selected: $dateTime');
+  },
+);
+```
+
+#### Direct Picker Dialogs
+```dart
+// Date only
+final date = await DateTimePicker.showDatePicker(
+  context: context,
+  initialDate: DateTime.now(),
+  firstDate: DateTime(2020),
+  lastDate: DateTime(2030),
+);
+
+// Time only
+final time = await DateTimePicker.showTimePicker(
+  context: context,
+  initialTime: TimeOfDay.now(),
+);
+
+// Date and time combined
+final dateTime = await DateTimePicker.showDateTimePicker(
+  context: context,
+  initialDateTime: DateTime.now(),
+);
+```
+
+---
+
+## Theming
+
+All components automatically use the app's theme provider. They adapt to:
+- Light/Dark mode
+- Primary/Secondary colors
+- Text styles
+- Card styles
+
+No additional configuration needed!
+
+---
+
+## Best Practices
+
+### 1. Use Consistent Spacing
+```dart
+Column(
+  children: [
+    CustomInput(label: 'Title'),
+    SizedBox(height: 16), // Consistent spacing
+    CustomInput(label: 'Description'),
+    SizedBox(height: 24), // Larger spacing before buttons
+    CustomButton(text: 'Save'),
+  ],
+)
+```
+
+### 2. Handle Loading States
+```dart
+bool _isLoading = false;
+
+CustomButton(
+  text: 'Save',
+  isLoading: _isLoading,
+  onPressed: () async {
+    setState(() => _isLoading = true);
+    await saveData();
+    setState(() => _isLoading = false);
+  },
+);
+```
+
+### 3. Validate Forms
+```dart
+final _formKey = GlobalKey<FormState>();
+
+Form(
+  key: _formKey,
+  child: Column(
+    children: [
+      CustomInput(
+        label: 'Email',
+        type: InputType.email,
+        validator: (value) {
+          if (value == null || !value.contains('@')) {
+            return 'Invalid email';
+          }
+          return null;
+        },
+      ),
+      CustomButton(
+        text: 'Submit',
+        onPressed: () {
+          if (_formKey.currentState!.validate()) {
+            // Process form
+          }
+        },
+      ),
+    ],
+  ),
+)
+```
+
+### 4. Use Controllers for Inputs
+```dart
+final _titleController = TextEditingController();
+
+@override
+void dispose() {
+  _titleController.dispose();
+  super.dispose();
+}
+
+CustomInput(
+  label: 'Title',
+  controller: _titleController,
+);
+
+// Access value: _titleController.text
+```
+
+---
+
+## Testing the Components
+
+Create a demo page to test all components:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:dayflow/widgets/ui_kit.dart';
+
+class UIKitDemoPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('UI Kit Demo')),
+      body: ListView(
+        padding: EdgeInsets.all(16),
+        children: [
+          Text('Buttons', style: Theme.of(context).textTheme.headlineSmall),
+          SizedBox(height: 16),
+          CustomButton(text: 'Primary Button', onPressed: () {}),
+          SizedBox(height: 8),
+          CustomButton(text: 'Secondary', type: ButtonType.secondary, onPressed: () {}),
+          SizedBox(height: 8),
+          CustomButton(text: 'Outlined', type: ButtonType.outlined, onPressed: () {}),
+          
+          SizedBox(height: 32),
+          Text('Inputs', style: Theme.of(context).textTheme.headlineSmall),
+          SizedBox(height: 16),
+          CustomInput(label: 'Text Input', hint: 'Enter text'),
+          SizedBox(height: 16),
+          CustomInput(label: 'Password', type: InputType.password),
+          SizedBox(height: 16),
+          SearchInput(hint: 'Search...'),
+          
+          SizedBox(height: 32),
+          Text('Cards', style: Theme.of(context).textTheme.headlineSmall),
+          SizedBox(height: 16),
+          InfoCard(
+            title: 'Sample Card',
+            subtitle: 'Card subtitle',
+            icon: Icons.info,
+            onTap: () {},
+          ),
+          
+          SizedBox(height: 32),
+          Text('Task Item', style: Theme.of(context).textTheme.headlineSmall),
+          SizedBox(height: 16),
+          TaskItem(
+            title: 'Sample Task',
+            description: 'This is a task description',
+            priority: TaskPriority.high,
+            dueDate: DateTime.now().add(Duration(days: 1)),
+            onToggleComplete: () {},
+          ),
+          
+          SizedBox(height: 32),
+          Text('Note Item', style: Theme.of(context).textTheme.headlineSmall),
+          SizedBox(height: 16),
+          NoteItem(
+            title: 'Sample Note',
+            content: 'This is note content that can be quite long...',
+            tags: ['demo', 'test'],
+            createdAt: DateTime.now(),
+            onTap: () {},
+          ),
+          
+          SizedBox(height: 32),
+          Text('Date/Time Pickers', style: Theme.of(context).textTheme.headlineSmall),
+          SizedBox(height: 16),
+          DatePickerField(
+            label: 'Date',
+            hint: 'Select date',
+            onChanged: (date) => print(date),
+          ),
+          SizedBox(height: 16),
+          TimePickerField(
+            label: 'Time',
+            hint: 'Select time',
+            onChanged: (time) => print(time),
+          ),
+          
+          SizedBox(height: 32),
+          CustomButton(
+            text: 'Show Modal Sheet',
+            onPressed: () {
+              CustomModalSheet.show(
+                context: context,
+                title: 'Demo Modal',
+                child: Column(
+                  children: [
+                    Text('This is a modal sheet'),
+                    SizedBox(height: 16),
+                    CustomButton(
+                      text: 'Close',
+                      onPressed: () => Navigator.pop(context),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+---
+
+## Component Summary
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| **CustomButton** | custom_button.dart | Primary, secondary, outlined, text buttons |
+| **CustomIconButton** | custom_button.dart | Compact icon buttons |
+| **CustomInput** | custom_input.dart | Text, password, email, number inputs |
+| **SearchInput** | custom_input.dart | Dedicated search field |
+| **CustomCard** | custom_card.dart | Basic card container |
+| **InfoCard** | custom_card.dart | Icon + title + subtitle card |
+| **StatCard** | custom_card.dart | Statistics display card |
+| **TaskItem** | task_item.dart | Task display with priority & dates |
+| **NoteItem** | note_item.dart | Note display with tags & pins |
+| **NoteItemCompact** | note_item.dart | Compact note for grids |
+| **CustomModalSheet** | modal_sheet.dart | Modal bottom sheet utilities |
+| **QuickActionSheet** | modal_sheet.dart | Quick action menu |
+| **DatePickerField** | date_time_picker.dart | Date selection field |
+| **TimePickerField** | date_time_picker.dart | Time selection field |
+| **DateTimePickerField** | date_time_picker.dart | Combined date/time field |
+| **DateTimePicker** | date_time_picker.dart | Direct picker dialogs |
+
+---
+
+## Next Steps for Team
+
+### Mohamed (Todo & Reminders Pages)
+
+**Use these components:**
+```dart
+// Todo Page
+TaskItem(
+  title: task.title,
+  description: task.description,
+  isCompleted: task.isCompleted,
+  priority: task.priority,
+  dueDate: task.dueDate,
+  onToggleComplete: () => toggleTask(task.id),
+  onEdit: () => editTask(task.id),
+  onDelete: () => deleteTask(task.id),
+);
+
+// Add task modal
+CustomModalSheet.showForm(
+  context: context,
+  title: 'Add Task',
+  child: Column(
+    children: [
+      CustomInput(label: 'Title', controller: titleController),
+      SizedBox(height: 16),
+      CustomInput(label: 'Description', type: InputType.multiline),
+      SizedBox(height: 16),
+      DateTimePickerField(label: 'Due Date', onChanged: (date) {}),
+    ],
+  ),
+  onConfirm: () => saveTask(),
+);
+
+// Reminders Page - Similar pattern
+```
+
+### Lina (Notes & Habits Pages)
+
+**Use these components:**
+```dart
+// Notes Page
+NoteItem(
+  title: note.title,
+  content: note.content,
+  tags: note.tags,
+  color: note.color,
+  isPinned: note.isPinned,
+  createdAt: note.createdAt,
+  onTap: () => viewNote(note.id),
+  onEdit: () => editNote(note.id),
+  onDelete: () => deleteNote(note.id),
+  onPin: () => togglePin(note.id),
+);
+
+// Add note modal
+CustomModalSheet.showForm(
+  context: context,
+  title: 'New Note',
+  child: Column(
+    children: [
+      CustomInput(label: 'Title', controller: titleController),
+      SizedBox(height: 16),
+      CustomInput(
+        label: 'Content',
+        type: InputType.multiline,
+        controller: contentController,
+      ),
+    ],
+  ),
+  onConfirm: () => saveNote(),
+);
+
+// Habits Page - Use StatCard for statistics display
+StatCard(
+  label: 'Current Streak',
+  value: '7 days',
+  icon: Icons.local_fire_department,
+  color: Colors.orange,
+);
+```
+
+### Abderrahmane (Settings & Polish)
+
+**Use these components:**
+```dart
+// Settings Page
+InfoCard(
+  title: 'Account Settings',
+  subtitle: 'Manage your profile',
+  icon: Icons.person,
+  onTap: () {},
+);
+
+InfoCard(
+  title: 'Notifications',
+  subtitle: 'Configure alerts',
+  icon: Icons.notifications,
+  onTap: () {},
+);
+
+InfoCard(
+  title: 'Theme',
+  subtitle: 'Light or dark mode',
+  icon: Icons.palette,
+  onTap: () => showThemeSelector(),
+);
+
+// Language selector
+CustomModalSheet.showListSelection<String>(
+  context: context,
+  title: 'Select Language',
+  items: ['English', 'Arabic', 'French'],
+  itemBuilder: (lang) => lang,
+  iconBuilder: (lang) => Icons.language,
+);
+```
+
+---
+
+## Customization Guide
+
+### Changing Button Colors
+Components use theme colors by default. To customize:
+
+```dart
+// In app_theme.dart, modify:
+static const Color primaryLight = Color(0xFF6366F1); // Your color
+static const Color secondaryLight = Color(0xFF8B5CF6); // Your color
+```
+
+### Custom Card Colors
+```dart
+CustomCard(
+  color: Colors.blue.shade50,
+  child: YourContent(),
+);
+```
+
+### Custom Input Styling
+All inputs follow the theme, but you can override:
+
+```dart
+CustomInput(
+  label: 'Custom',
+  // The component automatically uses theme colors
+  // No additional styling needed
+);
+```
+
+---
+
+## Common Issues & Solutions
+
+### Issue: "Provider not found"
+**Solution:** Make sure `ThemeProvider` is wrapped around `MaterialApp` in `main.dart`.
+
+### Issue: Date picker shows wrong theme
+**Solution:** The date picker automatically uses your app theme. Ensure `ThemeProvider` is properly set up.
+
+### Issue: Modal doesn't show
+**Solution:** Make sure you're calling `CustomModalSheet.show()` with a valid BuildContext.
+
+### Issue: Input validation not working
+**Solution:** Wrap inputs in a `Form` widget and use a `GlobalKey<FormState>`:
+
+```dart
+final _formKey = GlobalKey<FormState>();
+
+Form(
+  key: _formKey,
+  child: Column(
+    children: [
+      CustomInput(
+        validator: (value) {
+          if (value == null || value.isEmpty) {
+            return 'Required field';
+          }
+          return null;
+        },
+      ),
+    ],
+  ),
+);
+
+// Validate:
+if (_formKey.currentState!.validate()) {
+  // Proceed
+}
+```
+
+---
+
+## Component Feature Matrix
+
+| Component | Validation | Loading State | Disabled State | Theme Support |
+|-----------|------------|---------------|----------------|---------------|
+| CustomButton | ❌ | ✅ | ✅ | ✅ |
+| CustomInput | ✅ | ❌ | ✅ | ✅ |
+| CustomCard | ❌ | ❌ | ❌ | ✅ |
+| TaskItem | ❌ | ❌ | ❌ | ✅ |
+| NoteItem | ❌ | ❌ | ❌ | ✅ |
+| ModalSheet | ❌ | ❌ | ✅ | ✅ |
+| DatePicker | ❌ | ❌ | ✅ | ✅ |
+
+---
+
+## Learning Resources
+
+### Understand the Code
+Each component file includes:
+- Clear property documentation
+- Logical organization
+- Theme integration
+- Reusable patterns
+
+### Extend Components
+To add new features:
+
+1. Open the component file
+2. Add new properties to constructor
+3. Use properties in build method
+4. Update documentation
+
+Example - Adding badge to TaskItem:
+```dart
+// In task_item.dart constructor:
+final String? badge;
+
+// In build method:
+if (badge != null)
+  Container(
+    padding: EdgeInsets.all(4),
+    child: Text(badge!),
+  ),
+```
+
+---
+
+## Checklist for Team Members
+
+Before using components:
+- [ ] Import `'package:dayflow/widgets/ui_kit.dart'`
+- [ ] Check component documentation
+- [ ] Review usage examples
+- [ ] Test with light/dark themes
+- [ ] Handle edge cases (null values, long text)
+- [ ] Add proper error handling
+- [ ] Test on different screen sizes
+
+---
+
+## Support
+
+**Questions about components?**
+- Check this documentation first
+- Review the code comments
+- Test with the demo page
+- Ask Abderrahmane (Team Leader)
+
+**Branch:** `feature/abderrahmane/ui-kit`  
+**Complexity:** 3/5 
+**Status:** Ready for integration  
+
+---
+
+**All components are production-ready and tested!**

--- a/lib/widgets/modal_sheet.dart
+++ b/lib/widgets/modal_sheet.dart
@@ -1,0 +1,382 @@
+// Modal bottom sheet components
+
+import 'package:flutter/material.dart';
+import 'custom_button.dart';
+
+class CustomModalSheet {
+  // Show a custom modal bottom sheet
+  static Future<T?> show<T>({
+    required BuildContext context,
+    required Widget child,
+    String? title,
+    bool isDismissible = true,
+    bool enableDrag = true,
+    double? height,
+  }) {
+    return showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      isDismissible: isDismissible,
+      enableDrag: enableDrag,
+      backgroundColor: Colors.transparent,
+      builder: (context) => _ModalSheetWrapper(
+        title: title,
+        height: height,
+        child: child,
+      ),
+    );
+  }
+
+  // Show a form modal sheet with action buttons
+  static Future<bool?> showForm({
+    required BuildContext context,
+    required String title,
+    required Widget child,
+    String confirmText = 'Save',
+    String cancelText = 'Cancel',
+    required VoidCallback onConfirm,
+    VoidCallback? onCancel,
+    bool isDismissible = true,
+  }) {
+    return show<bool>(
+      context: context,
+      title: title,
+      isDismissible: isDismissible,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          child,
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: CustomButton(
+                  text: cancelText,
+                  type: ButtonType.outlined,
+                  onPressed: () {
+                    if (onCancel != null) onCancel();
+                    Navigator.pop(context, false);
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: CustomButton(
+                  text: confirmText,
+                  type: ButtonType.primary,
+                  onPressed: () {
+                    onConfirm();
+                    Navigator.pop(context, true);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Show a list selection modal sheet
+  static Future<T?> showListSelection<T>({
+    required BuildContext context,
+    required String title,
+    required List<T> items,
+    required String Function(T) itemBuilder,
+    IconData Function(T)? iconBuilder,
+    T? selectedItem,
+  }) {
+    return show<T>(
+      context: context,
+      title: title,
+      child: ListView.separated(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: items.length,
+        separatorBuilder: (context, index) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          final isSelected = item == selectedItem;
+
+          return ListTile(
+            leading: iconBuilder != null
+                ? Icon(
+              iconBuilder(item),
+              color: isSelected
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+            )
+                : null,
+            title: Text(
+              itemBuilder(item),
+              style: TextStyle(
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                color: isSelected
+                    ? Theme.of(context).colorScheme.primary
+                    : null,
+              ),
+            ),
+            trailing: isSelected
+                ? Icon(
+              Icons.check,
+              color: Theme.of(context).colorScheme.primary,
+            )
+                : null,
+            onTap: () => Navigator.pop(context, item),
+          );
+        },
+      ),
+    );
+  }
+
+  // Show a confirmation dialog modal
+  static Future<bool?> showConfirmation({
+    required BuildContext context,
+    required String title,
+    required String message,
+    String confirmText = 'Confirm',
+    String cancelText = 'Cancel',
+    bool isDangerous = false,
+  }) {
+    return show<bool>(
+      context: context,
+      title: title,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            message,
+            style: Theme.of(context).textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: CustomButton(
+                  text: cancelText,
+                  type: ButtonType.outlined,
+                  onPressed: () => Navigator.pop(context, false),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: CustomButton(
+                  text: confirmText,
+                  type: ButtonType.primary,
+                  onPressed: () => Navigator.pop(context, true),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// Internal wrapper widget for modal sheets
+class _ModalSheetWrapper extends StatelessWidget {
+  final String? title;
+  final Widget child;
+  final double? height;
+
+  const _ModalSheetWrapper({
+    this.title,
+    required this.child,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: theme.scaffoldBackgroundColor,
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(24),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Drag handle
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: theme.textTheme.bodyMedium?.color?.withOpacity(0.3),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+
+          // Title
+          if (title != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title!,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.pop(context),
+                    color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                  ),
+                ],
+              ),
+            ),
+
+          // Content
+          Flexible(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+              child: child,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// Quick action modal sheet
+class QuickActionSheet extends StatelessWidget {
+  final String title;
+  final List<QuickAction> actions;
+
+  const QuickActionSheet({
+    super.key,
+    required this.title,
+    required this.actions,
+  });
+
+  static Future<void> show({
+    required BuildContext context,
+    required String title,
+    required List<QuickAction> actions,
+  }) {
+    return CustomModalSheet.show(
+      context: context,
+      title: title,
+      child: QuickActionSheet(
+        title: title,
+        actions: actions,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: actions.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        final action = actions[index];
+        return _ActionTile(action: action);
+      },
+    );
+  }
+}
+
+class QuickAction {
+  final String title;
+  final String? subtitle;
+  final IconData icon;
+  final Color? color;
+  final VoidCallback onTap;
+
+  QuickAction({
+    required this.title,
+    this.subtitle,
+    required this.icon,
+    this.color,
+    required this.onTap,
+  });
+}
+
+class _ActionTile extends StatelessWidget {
+  final QuickAction action;
+
+  const _ActionTile({required this.action});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final actionColor = action.color ?? theme.colorScheme.primary;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () {
+          Navigator.pop(context);
+          action.onTap();
+        },
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: actionColor.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: actionColor.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  action.icon,
+                  color: actionColor,
+                  size: 24,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      action.title,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (action.subtitle != null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        action.subtitle!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.textTheme.bodyMedium?.color
+                              ?.withOpacity(0.7),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right,
+                color: theme.textTheme.bodyMedium?.color?.withOpacity(0.3),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/note_item.dart
+++ b/lib/widgets/note_item.dart
@@ -1,0 +1,309 @@
+// Note display widget
+
+import 'package:flutter/material.dart';
+
+class NoteItem extends StatelessWidget {
+  final String title;
+  final String content;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final Color? color;
+  final List<String>? tags;
+  final bool isPinned;
+  final VoidCallback? onTap;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+  final VoidCallback? onPin;
+
+  const NoteItem({
+    super.key,
+    required this.title,
+    required this.content,
+    this.createdAt,
+    this.updatedAt,
+    this.color,
+    this.tags,
+    this.isPinned = false,
+    this.onTap,
+    this.onEdit,
+    this.onDelete,
+    this.onPin,
+  });
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final difference = now.difference(date);
+
+    if (difference.inDays == 0) {
+      if (difference.inHours == 0) {
+        if (difference.inMinutes == 0) {
+          return 'Just now';
+        }
+        return '${difference.inMinutes}m ago';
+      }
+      return '${difference.inHours}h ago';
+    } else if (difference.inDays == 1) {
+      return 'Yesterday';
+    } else if (difference.inDays < 7) {
+      return '${difference.inDays}d ago';
+    } else {
+      return '${date.day}/${date.month}/${date.year}';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final noteColor = color ?? theme.colorScheme.primary.withOpacity(0.1);
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 0),
+      decoration: BoxDecoration(
+        color: theme.cardTheme.color ?? theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border(
+          left: BorderSide(
+            color: color ?? theme.colorScheme.primary,
+            width: 4,
+          ),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Header row with title and actions
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Pin indicator
+                    if (isPinned) ...[
+                      Icon(
+                        Icons.push_pin,
+                        size: 18,
+                        color: theme.colorScheme.primary,
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+
+                    // Title
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+
+                    // Menu button
+                    if (onEdit != null || onDelete != null || onPin != null)
+                      PopupMenuButton<String>(
+                        icon: Icon(
+                          Icons.more_vert,
+                          color: theme.textTheme.bodyMedium?.color
+                              ?.withOpacity(0.5),
+                          size: 20,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        onSelected: (value) {
+                          if (value == 'pin' && onPin != null) {
+                            onPin!();
+                          } else if (value == 'edit' && onEdit != null) {
+                            onEdit!();
+                          } else if (value == 'delete' && onDelete != null) {
+                            onDelete!();
+                          }
+                        },
+                        itemBuilder: (context) => [
+                          if (onPin != null)
+                            PopupMenuItem(
+                              value: 'pin',
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    isPinned ? Icons.push_pin_outlined : Icons.push_pin,
+                                    size: 20,
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Text(isPinned ? 'Unpin' : 'Pin'),
+                                ],
+                              ),
+                            ),
+                          if (onEdit != null)
+                            const PopupMenuItem(
+                              value: 'edit',
+                              child: Row(
+                                children: [
+                                  Icon(Icons.edit, size: 20),
+                                  SizedBox(width: 12),
+                                  Text('Edit'),
+                                ],
+                              ),
+                            ),
+                          if (onDelete != null)
+                            const PopupMenuItem(
+                              value: 'delete',
+                              child: Row(
+                                children: [
+                                  Icon(Icons.delete, size: 20, color: Colors.red),
+                                  SizedBox(width: 12),
+                                  Text('Delete', style: TextStyle(color: Colors.red)),
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+                  ],
+                ),
+
+                const SizedBox(height: 8),
+
+                // Content preview
+                Text(
+                  content,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.textTheme.bodyMedium?.color?.withOpacity(0.8),
+                  ),
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+
+                const SizedBox(height: 12),
+
+                // Footer with tags and date
+                Row(
+                  children: [
+                    // Tags
+                    if (tags != null && tags!.isNotEmpty)
+                      Expanded(
+                        child: Wrap(
+                          spacing: 6,
+                          runSpacing: 6,
+                          children: tags!.take(3).map((tag) {
+                            return Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: noteColor,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                '#$tag',
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                  color: color ?? theme.colorScheme.primary,
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ),
+
+                    // Date
+                    if (updatedAt != null || createdAt != null)
+                      Text(
+                        _formatDate(updatedAt ?? createdAt!),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.textTheme.bodyMedium?.color
+                              ?.withOpacity(0.5),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// Compact Note Item for grid view
+class NoteItemCompact extends StatelessWidget {
+  final String title;
+  final String content;
+  final Color? color;
+  final VoidCallback? onTap;
+
+  const NoteItemCompact({
+    super.key,
+    required this.title,
+    required this.content,
+    this.color,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final noteColor = color ?? theme.colorScheme.primary.withOpacity(0.1);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: noteColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: color ?? theme.colorScheme.primary.withOpacity(0.3),
+          width: 1,
+        ),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                Expanded(
+                  child: Text(
+                    content,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.textTheme.bodyMedium?.color
+                          ?.withOpacity(0.7),
+                    ),
+                    maxLines: 6,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/task_item.dart
+++ b/lib/widgets/task_item.dart
@@ -1,0 +1,320 @@
+// Task display widget
+
+import 'package:flutter/material.dart';
+
+enum TaskPriority { low, medium, high }
+
+class TaskItem extends StatelessWidget {
+  final String title;
+  final String? description;
+  final bool isCompleted;
+  final TaskPriority priority;
+  final DateTime? dueDate;
+  final String? category;
+  final VoidCallback? onTap;
+  final VoidCallback? onToggleComplete;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+
+  const TaskItem({
+    super.key,
+    required this.title,
+    this.description,
+    this.isCompleted = false,
+    this.priority = TaskPriority.medium,
+    this.dueDate,
+    this.category,
+    this.onTap,
+    this.onToggleComplete,
+    this.onEdit,
+    this.onDelete,
+  });
+
+  Color _getPriorityColor(BuildContext context) {
+    switch (priority) {
+      case TaskPriority.high:
+        return Colors.red;
+      case TaskPriority.medium:
+        return Colors.orange;
+      case TaskPriority.low:
+        return Colors.green;
+    }
+  }
+
+  String _getPriorityLabel() {
+    switch (priority) {
+      case TaskPriority.high:
+        return 'High';
+      case TaskPriority.medium:
+        return 'Medium';
+      case TaskPriority.low:
+        return 'Low';
+    }
+  }
+
+  String _formatDueDate() {
+    if (dueDate == null) return '';
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final taskDate = DateTime(dueDate!.year, dueDate!.month, dueDate!.day);
+
+    if (taskDate == today) {
+      return 'Today';
+    } else if (taskDate == today.add(const Duration(days: 1))) {
+      return 'Tomorrow';
+    } else if (taskDate.isBefore(today)) {
+      return 'Overdue';
+    } else {
+      return '${dueDate!.day}/${dueDate!.month}/${dueDate!.year}';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final priorityColor = _getPriorityColor(context);
+    final isOverdue = dueDate != null &&
+        dueDate!.isBefore(DateTime.now()) &&
+        !isCompleted;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 0),
+      decoration: BoxDecoration(
+        color: theme.cardTheme.color ?? theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isCompleted
+              ? Colors.green.withOpacity(0.3)
+              : (isOverdue ? Colors.red.withOpacity(0.3) : Colors.transparent),
+          width: isCompleted || isOverdue ? 2 : 0,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Checkbox
+                GestureDetector(
+                  onTap: onToggleComplete,
+                  child: Container(
+                    width: 24,
+                    height: 24,
+                    margin: const EdgeInsets.only(top: 2),
+                    decoration: BoxDecoration(
+                      color: isCompleted
+                          ? Colors.green
+                          : Colors.transparent,
+                      border: Border.all(
+                        color: isCompleted
+                            ? Colors.green
+                            : theme.textTheme.bodyMedium?.color
+                            ?.withOpacity(0.3) ??
+                            Colors.grey,
+                        width: 2,
+                      ),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: isCompleted
+                        ? const Icon(
+                      Icons.check,
+                      size: 16,
+                      color: Colors.white,
+                    )
+                        : null,
+                  ),
+                ),
+                const SizedBox(width: 12),
+
+                // Content
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Title
+                      Text(
+                        title,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          decoration: isCompleted
+                              ? TextDecoration.lineThrough
+                              : null,
+                          color: isCompleted
+                              ? theme.textTheme.bodyMedium?.color
+                              ?.withOpacity(0.5)
+                              : null,
+                        ),
+                      ),
+
+                      // Description
+                      if (description != null && description!.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          description!,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.textTheme.bodyMedium?.color
+                                ?.withOpacity(0.7),
+                            decoration: isCompleted
+                                ? TextDecoration.lineThrough
+                                : null,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+
+                      // Metadata row
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children: [
+                          // Priority badge
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 4,
+                            ),
+                            decoration: BoxDecoration(
+                              color: priorityColor.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: Text(
+                              _getPriorityLabel(),
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                                color: priorityColor,
+                              ),
+                            ),
+                          ),
+
+                          // Due date
+                          if (dueDate != null)
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: isOverdue
+                                    ? Colors.red.withOpacity(0.1)
+                                    : theme.colorScheme.primary
+                                    .withOpacity(0.1),
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    Icons.calendar_today,
+                                    size: 12,
+                                    color: isOverdue
+                                        ? Colors.red
+                                        : theme.colorScheme.primary,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    _formatDueDate(),
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w600,
+                                      color: isOverdue
+                                          ? Colors.red
+                                          : theme.colorScheme.primary,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+
+                          // Category
+                          if (category != null && category!.isNotEmpty)
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.secondary
+                                    .withOpacity(0.1),
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                category!,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: theme.colorScheme.secondary,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Action buttons
+                if (onEdit != null || onDelete != null)
+                  PopupMenuButton<String>(
+                    icon: Icon(
+                      Icons.more_vert,
+                      color: theme.textTheme.bodyMedium?.color
+                          ?.withOpacity(0.5),
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    onSelected: (value) {
+                      if (value == 'edit' && onEdit != null) {
+                        onEdit!();
+                      } else if (value == 'delete' && onDelete != null) {
+                        onDelete!();
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      if (onEdit != null)
+                        const PopupMenuItem(
+                          value: 'edit',
+                          child: Row(
+                            children: [
+                              Icon(Icons.edit, size: 20),
+                              SizedBox(width: 12),
+                              Text('Edit'),
+                            ],
+                          ),
+                        ),
+                      if (onDelete != null)
+                        const PopupMenuItem(
+                          value: 'delete',
+                          child: Row(
+                            children: [
+                              Icon(Icons.delete, size: 20, color: Colors.red),
+                              SizedBox(width: 12),
+                              Text('Delete', style: TextStyle(color: Colors.red)),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/ui_kit.dart
+++ b/lib/widgets/ui_kit.dart
@@ -1,0 +1,270 @@
+// UI Kit - Central export file for all custom components
+// Import this file to access all UI components in one place
+
+
+export 'custom_button.dart';
+export 'custom_input.dart';
+export 'custom_card.dart';
+export 'task_item.dart';
+export 'note_item.dart';
+export 'modal_sheet.dart';
+export 'date_time_picker.dart';
+// Usage Examples:
+//
+// 1. BUTTONS
+// ----------
+// import 'package:dayflow/widgets/ui_kit.dart';
+//
+// CustomButton(
+//   text: 'Save Task',
+//   type: ButtonType.primary,
+//   size: ButtonSize.large,
+//   icon: Icons.save,
+//   onPressed: () {
+//     // Save logic
+//   },
+// );
+//
+// CustomButton(
+//   text: 'Cancel',
+//   type: ButtonType.outlined,
+//   onPressed: () {
+//     // Cancel logic
+//   },
+// );
+//
+// CustomIconButton(
+//   icon: Icons.edit,
+//   onPressed: () {},
+//   tooltip: 'Edit',
+// );
+//
+// 2. INPUTS
+// ---------
+// CustomInput(
+//   label: 'Task Title',
+//   hint: 'Enter task title',
+//   type: InputType.text,
+//   prefixIcon: Icons.task,
+//   onChanged: (value) {
+//     // Handle change
+//   },
+//   validator: (value) {
+//     if (value == null || value.isEmpty) {
+//       return 'Please enter a title';
+//     }
+//     return null;
+//   },
+// );
+//
+// CustomInput(
+//   label: 'Password',
+//   type: InputType.password,
+//   prefixIcon: Icons.lock,
+// );
+//
+// SearchInput(
+//   hint: 'Search tasks...',
+//   onChanged: (value) {
+//     // Handle search
+//   },
+// );
+//
+// 3. CARDS
+// --------
+// CustomCard(
+//   onTap: () {},
+//   child: Column(
+//     children: [
+//       Text('Card Content'),
+//     ],
+//   ),
+// );
+//
+// InfoCard(
+//   title: 'Total Tasks',
+//   subtitle: 'Completed this week',
+//   icon: Icons.check_circle,
+//   iconColor: Colors.green,
+//   onTap: () {},
+// );
+//
+// StatCard(
+//   label: 'Tasks',
+//   value: '12',
+//   icon: Icons.task_alt,
+//   color: Colors.blue,
+// );
+//
+// 4. TASK ITEM
+// ------------
+// TaskItem(
+//   title: 'Complete project documentation',
+//   description: 'Write user guide and API docs',
+//   isCompleted: false,
+//   priority: TaskPriority.high,
+//   dueDate: DateTime.now().add(Duration(days: 2)),
+//   category: 'Work',
+//   onTap: () {
+//     // View task details
+//   },
+//   onToggleComplete: () {
+//     // Toggle completion status
+//   },
+//   onEdit: () {
+//     // Edit task
+//   },
+//   onDelete: () {
+//     // Delete task
+//   },
+// );
+//
+// 5. NOTE ITEM
+// ------------
+// NoteItem(
+//   title: 'Meeting Notes',
+//   content: 'Discussed project timeline and milestones...',
+//   createdAt: DateTime.now().subtract(Duration(hours: 2)),
+//   color: Colors.blue,
+//   tags: ['work', 'meeting'],
+//   isPinned: true,
+//   onTap: () {
+//     // View note
+//   },
+//   onEdit: () {
+//     // Edit note
+//   },
+//   onDelete: () {
+//     // Delete note
+//   },
+//   onPin: () {
+//     // Toggle pin
+//   },
+// );
+//
+// NoteItemCompact(
+//   title: 'Quick Idea',
+//   content: 'Build a feature for...',
+//   color: Colors.purple.withOpacity(0.2),
+//   onTap: () {},
+// );
+//
+// 6. MODAL SHEETS
+// ---------------
+// // Basic modal
+// CustomModalSheet.show(
+//   context: context,
+//   title: 'Add Task',
+//   child: Column(
+//     children: [
+//       CustomInput(label: 'Title', hint: 'Enter title'),
+//       SizedBox(height: 16),
+//       CustomButton(
+//         text: 'Save',
+//         onPressed: () {
+//           Navigator.pop(context);
+//         },
+//       ),
+//     ],
+//   ),
+// );
+//
+// // Form modal with actions
+// CustomModalSheet.showForm(
+//   context: context,
+//   title: 'Edit Task',
+//   child: CustomInput(label: 'Title'),
+//   confirmText: 'Save',
+//   cancelText: 'Cancel',
+//   onConfirm: () {
+//     // Save logic
+//   },
+// );
+//
+// // List selection modal
+// final priority = await CustomModalSheet.showListSelection<TaskPriority>(
+//   context: context,
+//   title: 'Select Priority',
+//   items: TaskPriority.values,
+//   itemBuilder: (item) => item.name,
+//   iconBuilder: (item) => Icons.flag,
+//   selectedItem: TaskPriority.medium,
+// );
+//
+// // Confirmation modal
+// final confirmed = await CustomModalSheet.showConfirmation(
+//   context: context,
+//   title: 'Delete Task',
+//   message: 'Are you sure you want to delete this task?',
+//   confirmText: 'Delete',
+//   cancelText: 'Cancel',
+//   isDangerous: true,
+// );
+//
+// // Quick action sheet
+// QuickActionSheet.show(
+//   context: context,
+//   title: 'Quick Actions',
+//   actions: [
+//     QuickAction(
+//       title: 'Add Task',
+//       subtitle: 'Create a new task',
+//       icon: Icons.add_task,
+//       onTap: () {},
+//     ),
+//     QuickAction(
+//       title: 'Add Note',
+//       subtitle: 'Create a quick note',
+//       icon: Icons.note_add,
+//       onTap: () {},
+//     ),
+//   ],
+// );
+//
+// 7. DATE/TIME PICKERS
+// --------------------
+// // Date picker field
+// DatePickerField(
+//   label: 'Due Date',
+//   hint: 'Select due date',
+//   prefixIcon: Icons.calendar_today,
+//   onChanged: (date) {
+//     print('Selected: $date');
+//   },
+// );
+//
+// // Time picker field
+// TimePickerField(
+//   label: 'Reminder Time',
+//   hint: 'Select time',
+//   prefixIcon: Icons.access_time,
+//   onChanged: (time) {
+//     print('Selected: $time');
+//   },
+// );
+//
+// // DateTime picker field
+// DateTimePickerField(
+//   label: 'Deadline',
+//   hint: 'Select date and time',
+//   prefixIcon: Icons.event,
+//   onChanged: (dateTime) {
+//     print('Selected: $dateTime');
+//   },
+// );
+//
+// // Direct picker dialogs
+// final date = await DateTimePicker.showDatePicker(
+//   context: context,
+//   initialDate: DateTime.now(),
+// );
+//
+// final time = await DateTimePicker.showTimePicker(
+//   context: context,
+//   initialTime: TimeOfDay.now(),
+// );
+//
+// final dateTime = await DateTimePicker.showDateTimePicker(
+//   context: context,
+//   initialDateTime: DateTime.now(),
+// );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,10 +66,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "3.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
@@ -131,6 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -139,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -209,5 +225,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,89 +1,38 @@
 name: dayflow
-description: "A new Flutter project."
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
+description: A smart daily planner for managing tasks, notes, and reminders
+publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.2
+  sdk: '>=3.0.0 <4.0.0'
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
+  # State Management
+  provider: ^6.1.5+1
+
+  # UI Components
+  cupertino_icons: ^1.0.6
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^3.0.0
 
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
-  flutter_lints: ^5.0.0
-
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
 
-  # To add assets to your application, add an assets section, like this:
+  # Uncomment to add assets
   # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  #   - images/
+  #   - icons/
 
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
+  # Uncomment to add custom fonts
   # fonts:
-  #   - family: Schyler
+  #   - family: Poppins
   #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
+  #       - asset: fonts/Poppins-Regular.ttf
+  #       - asset: fonts/Poppins-Bold.ttf
   #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package


### PR DESCRIPTION
- Added reusable button widgets (primary, secondary, outlined, disabled)
- Created input field components for text, password, and search
- Implemented generic Card, TaskItem, and NoteItem widgets
- Added modal bottom sheet and date/time picker wrappers
- Ensured all components follow the global theme provider
- Organized components under lib/widgets for reuse across the app
<img width="421" height="1171" alt="image" src="https://github.com/user-attachments/assets/846c072c-1b56-4f93-9829-932f0a767e4a" />


[dayflow_ui_kit_demo.md](https://github.com/user-attachments/files/23143049/dayflow_ui_kit_demo.md)
